### PR TITLE
Use indented formatting for JSON responses. Prettify log

### DIFF
--- a/WindowsPhoneDriver/WindowsPhoneDriver.Common/CommandResponse.cs
+++ b/WindowsPhoneDriver/WindowsPhoneDriver.Common/CommandResponse.cs
@@ -25,7 +25,7 @@
 
         public override string ToString()
         {
-            return string.Format("{0}: {1}", this.HttpStatusCode, this.Content);
+            return string.Format("{0}:\n{1}", this.HttpStatusCode, this.Content);
         }
 
         #endregion

--- a/WindowsPhoneDriver/WindowsPhoneDriver.InnerDriver/Commands/CommandBase.cs
+++ b/WindowsPhoneDriver/WindowsPhoneDriver.InnerDriver/Commands/CommandBase.cs
@@ -1,5 +1,7 @@
 ﻿namespace WindowsPhoneDriver.InnerDriver.Commands
 {
+    #region
+
     using System;
     using System.Collections.Generic;
     using System.Threading;
@@ -9,6 +11,8 @@
 
     using WindowsPhoneDriver.Common;
     using WindowsPhoneDriver.Common.Exceptions;
+
+    #endregion
 
     internal class CommandBase
     {
@@ -87,7 +91,7 @@
                 value = string.Format("WebDriverException {0}", Enum.GetName(typeof(ResponseStatus), status));
             }
 
-            return JsonConvert.SerializeObject(new JsonResponse(this.Session, status, value));
+            return JsonConvert.SerializeObject(new JsonResponse(this.Session, status, value), Formatting.Indented);
         }
 
         #endregion

--- a/WindowsPhoneDriver/WindowsPhoneDriver.OuterDriver/CommandExecutors/CommandExecutorBase.cs
+++ b/WindowsPhoneDriver/WindowsPhoneDriver.OuterDriver/CommandExecutors/CommandExecutorBase.cs
@@ -1,5 +1,7 @@
 ﻿namespace WindowsPhoneDriver.OuterDriver.CommandExecutors
 {
+    #region
+
     using System;
     using System.Net;
 
@@ -10,6 +12,8 @@
     using WindowsPhoneDriver.Common;
     using WindowsPhoneDriver.Common.Exceptions;
     using WindowsPhoneDriver.OuterDriver.Automator;
+
+    #endregion
 
     internal class CommandExecutorBase
     {
@@ -42,21 +46,19 @@
             }
             catch (AutomationException exception)
             {
-                return CommandResponse.Create(
-                    HttpStatusCode.OK,
-                    this.JsonResponse(exception.Status, exception));
+                return CommandResponse.Create(HttpStatusCode.OK, this.JsonResponse(exception.Status, exception));
             }
             catch (InnerDriverRequestException exception)
             {
                 // Bad status returned by Inner Driver when trying to forward command
                 return CommandResponse.Create(
-                    exception.StatusCode,
+                    exception.StatusCode, 
                     this.JsonResponse(ResponseStatus.UnknownError, exception));
             }
             catch (NotImplementedException exception)
             {
                 return CommandResponse.Create(
-                    HttpStatusCode.NotImplemented,
+                    HttpStatusCode.NotImplemented, 
                     this.JsonResponse(ResponseStatus.UnknownCommand, exception));
             }
             catch (Exception exception)
@@ -76,20 +78,11 @@
             throw new InvalidOperationException("DoImpl should never be called in CommandExecutorBase");
         }
 
-        /// <summary>
-        /// The JsonResponse with SUCCESS status and NULL value.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="string"/>.
-        /// </returns>
-        protected string JsonResponse()
+        protected string JsonResponse(ResponseStatus status = ResponseStatus.Success, object value = null)
         {
-            return this.JsonResponse(ResponseStatus.Success, null);
-        }
-
-        protected string JsonResponse(ResponseStatus status, object value)
-        {
-            return JsonConvert.SerializeObject(new JsonResponse(this.Automator.Session, status, value));
+            return JsonConvert.SerializeObject(
+                new JsonResponse(this.Automator.Session, status, value), 
+                Formatting.Indented);
         }
 
         #endregion

--- a/WindowsPhoneDriver/WindowsPhoneDriver.OuterDriver/Listener.cs
+++ b/WindowsPhoneDriver/WindowsPhoneDriver.OuterDriver/Listener.cs
@@ -177,10 +177,10 @@
             Logger.Info("COMMAND {0}\r\n{1}", command.Name, command.ParametersAsJsonString);
             var executor = this.executorDispatcher.GetExecutor(command.Name);
             executor.ExecutedCommand = command;
-            var respnose = executor.Do();
-            Logger.Debug("RESPONSE:\r\n{0}", respnose);
+            var response = executor.Do();
+            Logger.Debug("RESPONSE:\r\n{0}", response);
 
-            return respnose;
+            return response;
         }
 
         #endregion


### PR DESCRIPTION
Use indented formatting for serialization of responses. This results in more human-readable log.