### PR TITLE
Add terribly insecure cmd: executor for ISETool etc

### DIFF
--- a/WindowsPhoneDriver/WindowsPhoneDriver.OuterDriver/Automator/Capabilities.cs
+++ b/WindowsPhoneDriver/WindowsPhoneDriver.OuterDriver/Automator/Capabilities.cs
@@ -15,6 +15,7 @@
             this.LaunchTimeout = 10000;
             this.DebugConnectToRunningApp = false;
             this.InnerPort = 9998;
+            this.EnableJavascript = true;
         }
 
         #endregion
@@ -35,6 +36,9 @@
 
         [JsonProperty("debugConnectToRunningApp")]
         public bool DebugConnectToRunningApp { get; set; }
+
+        [JsonProperty("javascriptEnabled")]
+        public bool EnableJavascript { get; set; }
 
         [JsonProperty("deviceName")]
         public string DeviceName { get; set; }

--- a/WindowsPhoneDriver/WindowsPhoneDriver.OuterDriver/CommandExecutors/ExecuteScriptExecutor.cs
+++ b/WindowsPhoneDriver/WindowsPhoneDriver.OuterDriver/CommandExecutors/ExecuteScriptExecutor.cs
@@ -1,6 +1,7 @@
 ﻿namespace WindowsPhoneDriver.OuterDriver.CommandExecutors
 {
     using System;
+    using System.Diagnostics;
     using System.Globalization;
     using System.Windows.Forms;
 
@@ -11,33 +12,115 @@
     {
         #region Methods
 
+        public string RunExternalExe(string filename, string arguments = null)
+        {
+            var process = new Process();
+
+            process.StartInfo.FileName = filename;
+            if (!string.IsNullOrEmpty(arguments))
+            {
+                process.StartInfo.Arguments = arguments;
+            }
+
+            process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            process.StartInfo.UseShellExecute = false;
+
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.RedirectStandardOutput = true;
+            var stdOutput = new System.Text.StringBuilder();
+            process.OutputDataReceived += (sender, args) => stdOutput.Append(args.Data + "\n");
+
+            string stdError = null;
+            try
+            {
+                process.Start();
+                process.BeginOutputReadLine();
+                stdError = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+            }
+            catch (Exception e)
+            {
+                throw new Exception("OS error while executing " + Format(filename, arguments) + ": " + e.Message, e);
+            }
+
+            if (process.ExitCode == 0)
+            {
+                return stdOutput.ToString();
+            }
+            else
+            {
+                var message = new System.Text.StringBuilder();
+
+                if (!string.IsNullOrEmpty(stdError))
+                {
+                    message.AppendLine(stdError);
+                }
+
+                if (stdOutput.Length != 0)
+                {
+                    message.AppendLine("Std output:");
+                    message.AppendLine(stdOutput.ToString());
+                }
+
+                throw new Exception(Format(filename, arguments) + " finished with exit code = " + process.ExitCode + ": " + message);
+            }
+        }
+
+        private string Format(string filename, string arguments)
+        {
+            return "'" + filename +
+                ((string.IsNullOrEmpty(arguments)) ? string.Empty : " " + arguments) +
+                "'";
+        }
+
         protected override string DoImpl()
         {
             const string MobileScriptPrefix = "mobile:";
             var script = this.ExecutedCommand.Parameters["script"].ToString();
-            if (!script.StartsWith(MobileScriptPrefix, StringComparison.OrdinalIgnoreCase))
+            if (script.StartsWith(MobileScriptPrefix, StringComparison.OrdinalIgnoreCase))
             {
-                throw new NotImplementedException(
-                    "execute partially implemented, supports only mobile: prefixed commands");
-            }
+                var command = script.Split(':')[1].ToLower(CultureInfo.InvariantCulture).Trim();
 
-            var command = script.Split(':')[1].ToLower(CultureInfo.InvariantCulture).Trim();
-
-            if (command.Equals("start"))
-            {
-                this.Automator.EmulatorController.TypeKey(Keys.F2);
+                if (command.Equals("start"))
+                {
+                    this.Automator.EmulatorController.TypeKey(Keys.F2);
+                }
+                else if (command.Equals("search"))
+                {
+                    this.Automator.EmulatorController.TypeKey(Keys.F3);
+                }
+                else
+                {
+                    throw new AutomationException(
+                        "Unknown 'mobile:' script command. See https://github.com/2gis/winphonedriver/wiki/Command-Execute-Script for supported commands.",
+                        ResponseStatus.JavaScriptError);
+                }
             }
-            else if (command.Equals("search"))
+            else if (script.StartsWith("cmd:", StringComparison.OrdinalIgnoreCase))
             {
-                this.Automator.EmulatorController.TypeKey(Keys.F3);
+                var command = script.Split(new char[] { ':' }, 2)[1];
+                var cmd = "";
+                var args = "";
+                if (command.StartsWith("\""))
+                {
+                    var parts = command.Split(new char[] { '"' }, 3);
+                    cmd = parts[1];
+                    args = parts[2];
+                }
+                else
+                {
+                    var parts = command.Split(new char[] { ' ' }, 2);
+                    cmd = parts[0];
+                    args = parts[1];
+                }
+                return this.JsonResponse(ResponseStatus.Success, RunExternalExe(cmd, args));
             }
             else
             {
-                throw new AutomationException(
-                    "Unknown 'mobile:' script command. See https://github.com/2gis/winphonedriver/wiki/Command-Execute-Script for supported commands.", 
-                    ResponseStatus.JavaScriptError);
+                throw new NotImplementedException(
+                    "execute partially implemented, supports only mobile: or cmd: prefixed commands");
             }
-
             return this.JsonResponse();
         }
 


### PR DESCRIPTION
My first C#!

I know this is horribly insecure, but we're using it for retrieving logs from the phone when the tests are running on a different host: ssh can't access the desktop processes.

    def retrieve_phone_log
        tmp = 'wphonetemp'
        driver.execute_script("cmd:cmd /c \"rd /s/q #{tmp} & md #{tmp}\"")
        isetool = 'c:\Program Files (x86)\Microsoft SDKs\Windows Phone\v8.1\Tools\IsolatedStorageExplorerTool\ISETool.exe'
        $devices ||= driver.execute_script("cmd:\"#{isetool}\" enumeratedevices").split("\n")
        $devindex ||= $devices.grep(/#{driver.capabilities['deviceName']}/).first.split.first
        log = driver.execute_script("cmd:\"#{isetool}\" ts deviceindex:#{$devindex} #{ENV['WINPHONE_APP_ID']} #{tmp}")
        log + driver.execute_script("cmd:cmd /c \"tree /f /a #{tmp} & type #{tmp}\\IsolatedStore\\BadooDebugLog.txt & echo DONE.\"")
    end