### PR TITLE
Fix listener crashing on empty incoming request

### DIFF
--- a/WindowsPhoneDriver/WindowsPhoneDriver.OuterDriver/Listener.cs
+++ b/WindowsPhoneDriver/WindowsPhoneDriver.OuterDriver/Listener.cs
@@ -89,19 +89,27 @@
                     using (var stream = client.GetStream())
                     {
                         var acceptedRequest = HttpRequest.ReadFromStreamWithoutClosing(stream);
-                        Logger.Debug("ACCEPTED REQUEST {0}", acceptedRequest.StartingLine);
 
-                        var response = this.HandleRequest(acceptedRequest);
-                        using (var writer = new StreamWriter(stream))
+                        if (string.IsNullOrWhiteSpace(acceptedRequest.StartingLine))
                         {
-                            try
+                            Logger.Warn("ACCEPTED EMPTY REQUEST");
+                        }
+                        else
+                        {
+                            Logger.Debug("ACCEPTED REQUEST {0}", acceptedRequest.StartingLine);
+
+                            var response = this.HandleRequest(acceptedRequest);
+                            using (var writer = new StreamWriter(stream))
                             {
-                                writer.Write(response);
-                                writer.Flush();
-                            }
-                            catch (IOException ex)
-                            {
-                                Logger.Error("Error occured while writing response: {0}", ex);
+                                try
+                                {
+                                    writer.Write(response);
+                                    writer.Flush();
+                                }
+                                catch (IOException ex)
+                                {
+                                    Logger.Error("Error occured while writing response: {0}", ex);
+                                }
                             }
                         }
 


### PR DESCRIPTION
Driver works fine with selenium==2.45.0, but crashes when selenium==2.53.6 is used.
Driver crashes due to empty (non HTTP) request being accepted.