### PR TITLE
support for basic property chaining in GetAttribute command

### DIFF
--- a/WindowsPhoneDriver/TestApp.Test/fsharp/test_commands.fsx
+++ b/WindowsPhoneDriver/TestApp.Test/fsharp/test_commands.fsx
@@ -9,7 +9,7 @@ open OpenQA.Selenium.Remote
 // from TestApp.Test\py-functional\config.py
 let desiredCapabilities () = 
     let capabilities = new DesiredCapabilities()
-    let xapPath = System.IO.Path.Combine(__SOURCE_DIRECTORY__, "../TestApp/Bin/x86/Debug/TestApp_Debug_x86.xap")
+    let xapPath = System.IO.Path.Combine(__SOURCE_DIRECTORY__, "../../TestApp/Bin/x86/Debug/TestApp_Debug_x86.xap")
     capabilities.SetCapability("app", xapPath)
     capabilities.SetCapability("deviceName", "Emulator 8.1")
     capabilities.IsJavaScriptEnabled <- true
@@ -21,3 +21,7 @@ let getDriver () =
 let driver = getDriver()
 driver.ExecuteScript("mobile: invokeMethod", "TestApp.AutomationApi", "Alert", "blah blah")
 driver.ExecuteScript("mobile: invokeMethod", "TestApp.AutomationApi", "AlertEmpty")
+
+driver.FindElementById("SetButton").GetAttribute("DataContext.SampleProperty")
+driver.FindElementById("SetButton").GetAttribute("Background.Color")
+driver.FindElementById("SetButton").GetAttribute("RenderTransform")

--- a/WindowsPhoneDriver/WindowsPhoneDriver.InnerDriver/Commands/GetElementAttributeCommand.cs
+++ b/WindowsPhoneDriver/WindowsPhoneDriver.InnerDriver/Commands/GetElementAttributeCommand.cs
@@ -1,9 +1,9 @@
 ﻿namespace WindowsPhoneDriver.InnerDriver.Commands
 {
-	using System;
-	using System.Linq;
+    using System;
+    using System.Linq;
 
-	using WindowsPhoneDriver.Common;
+    using WindowsPhoneDriver.Common;
 
     internal class GetElementAttributeCommand : CommandBase
     {
@@ -31,16 +31,16 @@
                 return this.JsonResponse(ResponseStatus.Success, null);
             }
 
-			//Support for attributes with chained names like "Control.RenderTransform.TranslateX"
-	        var finalValue = attributeName
-				.Split('.')
-				.Aggregate(
-					(object)element,
-					(currentValue, propertyName) =>
-						{
-							var prop = currentValue?.GetType().GetProperty(propertyName);
-							return currentValue == null || prop == null ? null : prop.GetValue(currentValue);
-						});
+            //Support for attributes with chained names like "Control.RenderTransform.TranslateX"
+            var finalValue = attributeName
+                .Split('.')
+                .Aggregate(
+                    (object)element,
+                    (currentValue, propertyName) =>
+                        {
+                            var prop = currentValue?.GetType().GetProperty(propertyName);
+                            return currentValue == null || prop == null ? null : prop.GetValue(currentValue);
+                        });
 
             if (finalValue == null)
             {


### PR DESCRIPTION
added ability to use chained (via dot) attributes that will map to real visual tree objects via reflection.
E.g.:
`driver.FindElementById("SetButton").GetAttribute("DataContext.SampleProperty")
driver.FindElementById("SetButton").GetAttribute("Background.Color")`