### PR TITLE
Change logic for deviceName matching

### DIFF
--- a/WindowsPhoneDriver/Winium.Mobile.Connectivity/Devices.cs
+++ b/WindowsPhoneDriver/Winium.Mobile.Connectivity/Devices.cs
@@ -50,13 +50,12 @@
         public DeviceInfo GetMatchingDevice(string desiredName, bool strict)
         {
             DeviceInfo deviceInfo;
-            if (strict)
-            {
-                deviceInfo =
-                    this.AvailableDevices.FirstOrDefault(
-                        x => x.ToString().Equals(desiredName, StringComparison.OrdinalIgnoreCase));
-            }
-            else
+
+            deviceInfo =
+                this.AvailableDevices.FirstOrDefault(
+                    x => x.ToString().Equals(desiredName, StringComparison.OrdinalIgnoreCase));
+
+            if (!strict && deviceInfo == null)
             {
                 deviceInfo =
                     this.AvailableDevices.FirstOrDefault(


### PR DESCRIPTION
If deviceName is identical to emulator name then this emulator will be used,
otherwise, will be chosen the first one emulator which name starts with given deviceName

This should prevent a case when `Emulator 8.1 WVGA 4 inch 512MB` is matched `Emulator 8.1 WVGA 4 inch` before `Emulator 8.1 WVGA 4 inch` itself.
